### PR TITLE
Use theme as module for exampleSite

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -3,7 +3,6 @@ language: en
 defaultContentLanguage: en
 languageCode: en-ca
 title: Cupper-hugo-dfd-x
-theme: cupper-hugo-dfd-x
 googleAnalytics: ""
 disqusShortname: yourdiscussshortname
 enableGitInfo: true
@@ -87,3 +86,7 @@ markup:
   tableOfContents:
     endLevel: 6
     startLevel: 2
+
+module:
+  imports:
+    - path: github.com/danielfdickinson/cupper-hugo-dfd-x

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,3 +1,5 @@
 module github.com/danielfdickinson/cupper-hugo-dfd-x-exampleSite
 
 go 1.17
+
+require github.com/danielfdickinson/cupper-hugo-dfd-x v0.0.0-20210906041210-db36f81239c2 // indirect

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,0 +1,2 @@
+github.com/danielfdickinson/cupper-hugo-dfd-x v0.0.0-20210906041210-db36f81239c2 h1:ZCr3iLS3eWVWz89xVXysJ78HYLo4jbppaGWCwgxQL+Q=
+github.com/danielfdickinson/cupper-hugo-dfd-x v0.0.0-20210906041210-db36f81239c2/go.mod h1:F5l2poYMDly0NHB9s9IfUklPF6tqb6DuATYNo0Ek53s=


### PR DESCRIPTION
Use HUGO_MODULE_REPLACEMENTS environment to build against current
version of theme module (avoiding chicken and egg problem) when
deploying exampleSite and doing module CI.

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>