### PR TITLE
Default to safer settings for external links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="nofollow noopener"{{ end }}>{{ if .Text }}{{ .Text | safeHTML }}{{ else }}{{ .Destination | safeHTML }}{{ end }}</a>


### PR DESCRIPTION
Also, if the link doesn't have text, make the text the same as the
destination URL

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>